### PR TITLE
EMP-15109 - Fixed issue where playback did not work with iOS 12 or older devices. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+* `2.2.20` Release - [2.2.20](#2220)
 * `2.2.10` Release - [2.2.10](#2210)
 * `2.2.00` Release - [2.2.00](#2200)
 * `2.1.00` Release - [2.1.00](#2100)
@@ -18,6 +19,10 @@
 * `0.72.x` Releases - [0.72.0](#0720)
 * `0.2.x` Releases - [0.2.0](#020)
 * `0.1.x` Releases - [0.1.0](#010) | [0.1.1](#011) | [0.1.2](#012) | [0.1.3](#013) | [0.1.4](#014) | [0.1.5](#015)
+
+## 2.2.200
+#### Bug Fixes
+* `EMP-15109` Fixed issue where playback did not work with iOS 12 or older devices. 
 
 ## 2.2.100
 #### Changes

--- a/Player.xcodeproj/project.pbxproj
+++ b/Player.xcodeproj/project.pbxproj
@@ -983,7 +983,7 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = JCUPRVKEC5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -998,7 +998,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.2.100;
+				MARKETING_VERSION = 2.2.200;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Player;
 				PRODUCT_NAME = Player;
@@ -1020,7 +1020,7 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = JCUPRVKEC5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1035,7 +1035,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.2.100;
+				MARKETING_VERSION = 2.2.200;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Player;
 				PRODUCT_NAME = Player;
@@ -1167,7 +1167,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = JCUPRVKEC5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1182,7 +1182,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/Frameworks @executable_path/Frameworks";
-				MARKETING_VERSION = 2.2.100;
+				MARKETING_VERSION = 2.2.200;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Player;
 				PRODUCT_NAME = Player;
@@ -1198,7 +1198,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = JCUPRVKEC5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1213,7 +1213,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/Frameworks @executable_path/Frameworks";
-				MARKETING_VERSION = 2.2.100;
+				MARKETING_VERSION = 2.2.200;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Player;
 				PRODUCT_NAME = Player;

--- a/Player/Info.plist
+++ b/Player/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Player/Tech/HLS/HLSNative.swift
+++ b/Player/Tech/HLS/HLSNative.swift
@@ -131,9 +131,9 @@ public final class HLSNative<Context: MediaContext>: PlaybackTech {
             
             let asset = AVURLAsset(url: source.url, options: nil)
             
-            if !asset.resourceLoader.preloadsEligibleContentKeys {
+            /* if !asset.resourceLoader.preloadsEligibleContentKeys {
                 asset.resourceLoader.preloadsEligibleContentKeys = true
-            }
+            } */
             
 
             if fairplayRequester != nil {
@@ -587,21 +587,6 @@ extension HLSNative {
                         
                         print("Failed ", item.errorLog())
                         self.handleStartTime(mediaAsset: mediaAsset, callback: onReady)
-                        
-//                        print("handleStatusChange : failed Code ", item.error)
-//
-//                        let techError = PlayerError<HLSNative<Context>,Context>.tech(error: HLSNativeError.failedToReady(error: item.error))
-//
-//                        print("handleStatusChange : failed Code ", techError.code)
-//
-//                        if techError.code != 103 {
-//                            self.eventDispatcher.onError(self, mediaAsset.source, techError)
-//                            mediaAsset.prepareTrace().forEach{ mediaAsset.source.analyticsConnector.onTrace(tech: self, source: mediaAsset.source, data: $0) }
-//                            mediaAsset.source.analyticsConnector.onError(tech: self, source: mediaAsset.source, error: techError)
-//                        } else {
-//                            print("No Interent but still trying to play ")
-//                        }
-                        
                     }
                 }
             }


### PR DESCRIPTION
Update version & change log
Remove `resourceLoader.preloadsEligibleContentKeys = YES` as it breaks the playback on older iOS versions