### PR TITLE
EMP-17693

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+* `2.4.00` Release - [2.4.00](#2400)
 * `2.3.10` Release - [2.3.10](#2310)
 * `2.3.00` Release - [2.3.00](#2300)
 * `2.2.30` Release - [2.2.30](#2230)
@@ -22,6 +23,10 @@
 * `0.72.x` Releases - [0.72.0](#0720)
 * `0.2.x` Releases - [0.2.0](#020)
 * `0.1.x` Releases - [0.1.0](#010) | [0.1.1](#011) | [0.1.2](#012) | [0.1.3](#013) | [0.1.4](#014) | [0.1.5](#015)
+
+## 2.4.000
+#### Features
+* `EMP-17693` Allow client developers to access `AVAssetVariant` s in the `currentAsset` 
 
 ## 2.3.100
 #### Changes

--- a/Documentation/Bitrates-Framerates-Resolutions.md
+++ b/Documentation/Bitrates-Framerates-Resolutions.md
@@ -1,0 +1,21 @@
+## Bitrates / Framerates & Resolutions 
+
+Client applications using a `Tech` which adopts the `TrackSelectable` *api*, such as `HLSNative`, have access to `AVAssetVariant` s in the current Player Item using below *api* .
+
+```Swift
+let availableVariants  = player.variants
+```
+
+The *api* will return the array of `AVAssetVariant`s . This is available from **iOS 15.xx , tvOS 15.xx** and above only.
+
+```Swift
+if #available(iOS 15.0, *) {
+   let _ = self.player.variants?.compactMap { variant in
+   print(variant.peakBitRate)
+   print(variant.videoAttributes?.nominalFrameRate)
+   print(variant.videoAttributes?.presentationSize)
+}
+} else {
+    // Fallback on earlier versions
+}
+```

--- a/Player.xcodeproj/project.pbxproj
+++ b/Player.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 		76EA01DB203EB20700B32345 /* HLSNativeConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HLSNativeConfiguration.swift; sourceTree = "<group>"; };
 		76EA01DD203EE72200B32345 /* HLSNativeNetworkBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HLSNativeNetworkBehavior.swift; sourceTree = "<group>"; };
 		76EA01DF203EEC0E00B32345 /* HLSNative+NetworkBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HLSNative+NetworkBehavior.swift"; sourceTree = "<group>"; };
+		7838DD0327A934850052848A /* Bitrates-Framerates-Resolutions.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Bitrates-Framerates-Resolutions.md"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -457,6 +458,7 @@
 				76BCE07C20482F4300F1E49C /* custom-playback-controls.md */,
 				76BCE07E20482F6400F1E49C /* error-handling.md */,
 				76BCE080204844BF00F1E49C /* subtitles-and-multi-audio.md */,
+				7838DD0327A934850052848A /* Bitrates-Framerates-Resolutions.md */,
 			);
 			path = Documentation;
 			sourceTree = SOURCE_ROOT;
@@ -987,7 +989,7 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = JCUPRVKEC5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1003,7 +1005,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.3.200;
+				MARKETING_VERSION = 2.4.000;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Player;
 				PRODUCT_NAME = Player;
@@ -1026,7 +1028,7 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = JCUPRVKEC5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1042,7 +1044,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.3.200;
+				MARKETING_VERSION = 2.4.000;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Player;
@@ -1176,7 +1178,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = JCUPRVKEC5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1192,7 +1194,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/Frameworks @executable_path/Frameworks";
-				MARKETING_VERSION = 2.3.200;
+				MARKETING_VERSION = 2.4.000;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Player;
 				PRODUCT_NAME = Player;
@@ -1210,7 +1212,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = JCUPRVKEC5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1226,7 +1228,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/Frameworks @executable_path/Frameworks";
-				MARKETING_VERSION = 2.3.200;
+				MARKETING_VERSION = 2.4.000;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Player;
 				PRODUCT_NAME = Player;

--- a/Player/Components/TrackSelectable.swift
+++ b/Player/Components/TrackSelectable.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import AVFoundation
 
 public protocol Track {
     /// Should return a human readable display name of the track
@@ -28,6 +29,10 @@ public protocol TrackSelectable {
     
     /// Should fetch all associated audio tracks
     var audioTracks: [AudioTrack] { get }
+    
+    /// Should fetch all associated `AVAssetVariant` s
+    @available(iOS 15.0, tvOS 15.0, *)
+    var variants: [AVAssetVariant]? { get }
     
     /// Should fetch the selected audio track if available, otherwise `nil`
     var selectedAudioTrack: AudioTrack? { get }

--- a/Player/Info.plist
+++ b/Player/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Player/Tech/HLS/Components/HLSNative+TrackSelectable.swift
+++ b/Player/Tech/HLS/Components/HLSNative+TrackSelectable.swift
@@ -17,6 +17,15 @@ extension HLSNative: TrackSelectable {
             .audioGroup
     }
     
+    
+    @available(iOS 15.0,tvOS 15.0, *)
+    /// Returns all the available `AVAssetVariant`
+    public var variants: [AVAssetVariant]? {
+        return currentAsset?.urlAsset.variants
+    }
+
+    
+    
     /// Returns the default audio track, or `nil` if unavailable
     public var defaultAudioTrack: MediaTrack? {
         return audioGroup?.defaultTrack


### PR DESCRIPTION
Allow client developers to access `AVAssetVariant` s in the `currentAsset`
Update version & change log
Update documentation