### PR TITLE
Analytics support for offline playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+* `3.2.0` Release - [3.2.0](#320)
 * `3.1.60` Release - [3.1.600](#31600)
 * `3.1.50` Release - [3.1.500](#31500)
 * `3.1.40` Release - [3.1.400](#31400)
@@ -44,6 +45,11 @@
 * `0.72.x` Releases - [0.72.0](#07200)
 * `0.2.x` Releases - [0.2.0](#020)
 * `0.1.x` Releases - [0.1.0](#010) | [0.1.1](#011) | [0.1.2](#012) | [0.1.3](#013) | [0.1.4](#014) | [0.1.5](#015)
+
+## 3.2.0
+#### Changes
+* `EMP-20039` Added functionality for analytics for offline playback.
+* `EMP-20039` Bumped up the minimum deployment version to `iOS/tvOS 12`.
 
 ## 3.1.600
 #### Changes

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,43 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "a23ded2c91df9156628a6996ab4f347526f17b6b",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "c93f16c25af5770f0d3e6af27c9634640946b068",
+          "version": "9.2.1"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "bd86ca0141e3cfb333546de5a11ede63f0c4a0e6",
+          "version": "4.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 
 let package = Package(
     name: "iOSClientPlayer",
-    platforms: [.iOS(.v10),
-                .tvOS(.v10)],
+    platforms: [.iOS(.v12),
+                .tvOS(.v12)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Once you have your Swift package set up, adding `iOSClientPlayer` as a dependenc
 
 ```sh
 dependencies: [
-    .package(url: "https://github.com/EricssonBroadcastServices/iOSClientPlayer", from: "3.1.6")
+    .package(url: "https://github.com/EricssonBroadcastServices/iOSClientPlayer", from: "3.2.0")
 ]
 ```
 
@@ -82,7 +82,7 @@ Finaly, make sure you add the `.framework`s to your targets *General -> Embedded
 CocoaPods is a dependency manager for Cocoa projects. For usage and installation instructions, visit their website. To integrate `iOSClientPlayer` into your Xcode project using CocoaPods, specify it in your Podfile:
 
 ```sh
-pod 'iOSClientPlayer', '~>  3.1.6'
+pod 'iOSClientPlayer', '~>  3.2.0'
 ```
 
 ## Release Notes

--- a/Sources/iOSClientPlayer/Analytics/Connectors/PassThroughConnector.swift
+++ b/Sources/iOSClientPlayer/Analytics/Connectors/PassThroughConnector.swift
@@ -86,6 +86,10 @@ public class PassThroughConnector: AnalyticsConnector {
         providers.forEach{ $0.onAppDidEnterBackground(tech: tech, source: source) }
     }
     
+    public func onAppDidEnterForeground<Tech, Source>(tech: Tech, source: Source?) where Tech : PlaybackTech, Source : MediaSource {
+        providers.forEach{ $0.onAppDidEnterForeground(tech: tech, source: source) }
+    }
+    
     public func onGracePeriodStarted<Tech, Source>(tech: Tech, source: Source?) where Tech : PlaybackTech, Source : MediaSource {
         providers.forEach{ $0.onGracePeriodStarted(tech: tech, source: source) }
     }

--- a/Sources/iOSClientPlayer/Analytics/Connectors/PassThroughConnector.swift
+++ b/Sources/iOSClientPlayer/Analytics/Connectors/PassThroughConnector.swift
@@ -10,6 +10,8 @@ import Foundation
 
 /// Simple `AnalyticsConnector` that forwards all events to the specified `AnalyticsProvider`s
 public class PassThroughConnector: AnalyticsConnector {
+
+    
     public init(providers: [AnalyticsProvider] = []) {
         self.providers = providers
     }
@@ -78,5 +80,17 @@ public class PassThroughConnector: AnalyticsConnector {
     
     public func onWarning<Tech, Source, Context>(tech: Tech, source: Source?, warning: PlayerWarning<Tech, Context>) where Tech : PlaybackTech, Source : MediaSource, Context : MediaContext {
         providers.forEach{ $0.onWarning(tech: tech, source: source, warning: warning) }
+    }
+    
+    public func onAppDidEnterBackground<Tech, Source>(tech: Tech, source: Source?) where Tech : PlaybackTech, Source : MediaSource {
+        providers.forEach{ $0.onAppDidEnterBackground(tech: tech, source: source) }
+    }
+    
+    public func onGracePeriodStarted<Tech, Source>(tech: Tech, source: Source?) where Tech : PlaybackTech, Source : MediaSource {
+        providers.forEach{ $0.onGracePeriodStarted(tech: tech, source: source) }
+    }
+    
+    public func onGracePeriodEnded<Tech, Source>(tech: Tech, source: Source?) where Tech : PlaybackTech, Source : MediaSource {
+        providers.forEach{ $0.onGracePeriodEnded(tech: tech, source: source) }
     }
 }

--- a/Sources/iOSClientPlayer/Analytics/Providers/AnalyticsLogger.swift
+++ b/Sources/iOSClientPlayer/Analytics/Providers/AnalyticsLogger.swift
@@ -10,6 +10,8 @@ import Foundation
 
 /// Simple `AnalyticsProvider` that logs any events it receives to the console.
 public struct AnalyticsLogger: AnalyticsProvider {
+
+    
     public init() { }
     public func onCreated<Tech, Source>(tech: Tech, source: Source) where Tech : PlaybackTech, Source : MediaSource {
         print("🏷 AnalyticsLogger",type(of: tech),"🏗 onCreated",source.playSessionId)
@@ -69,5 +71,17 @@ public struct AnalyticsLogger: AnalyticsProvider {
     
     public func onWarning<Tech, Source, Context>(tech: Tech, source: Source?, warning: PlayerWarning<Tech, Context>) where Tech : PlaybackTech, Source : MediaSource, Context : MediaContext {
         print("🏷 AnalyticsLogger",type(of: tech),"⚠️ onWarning",warning.message,source?.playSessionId ?? "")
+    }
+    
+    public func onAppDidEnterBackground<Tech, Source>(tech: Tech, source: Source?) where Tech : PlaybackTech, Source : MediaSource {
+        print("🏷 AnalyticsLogger",type(of: tech),"⍂ onAppDidEnterBackground",source?.playSessionId ?? "" )
+    }
+    
+    public func onGracePeriodStarted<Tech, Source>(tech: Tech, source: Source?) where Tech : PlaybackTech, Source : MediaSource {
+        print("🏷 AnalyticsLogger",type(of: tech),"⏳ onGracePeriodStarted",source?.playSessionId ?? "" )
+    }
+    
+    public func onGracePeriodEnded<Tech, Source>(tech: Tech, source: Source?) where Tech : PlaybackTech, Source : MediaSource {
+        print("🏷 AnalyticsLogger",type(of: tech),"⌛️ onGracePeriodEnded",source?.playSessionId ?? "" )
     }
 }

--- a/Sources/iOSClientPlayer/Analytics/Providers/AnalyticsLogger.swift
+++ b/Sources/iOSClientPlayer/Analytics/Providers/AnalyticsLogger.swift
@@ -77,6 +77,10 @@ public struct AnalyticsLogger: AnalyticsProvider {
         print("🏷 AnalyticsLogger",type(of: tech),"⍂ onAppDidEnterBackground",source?.playSessionId ?? "" )
     }
     
+    public func onAppDidEnterForeground<Tech, Source>(tech: Tech, source: Source?) where Tech : PlaybackTech, Source : MediaSource {
+        print("🏷 AnalyticsLogger",type(of: tech),"⍂ onAppDidEnterForeground",source?.playSessionId ?? "" )
+    }
+    
     public func onGracePeriodStarted<Tech, Source>(tech: Tech, source: Source?) where Tech : PlaybackTech, Source : MediaSource {
         print("🏷 AnalyticsLogger",type(of: tech),"⏳ onGracePeriodStarted",source?.playSessionId ?? "" )
     }

--- a/Sources/iOSClientPlayer/Components/MediaPlayback.swift
+++ b/Sources/iOSClientPlayer/Components/MediaPlayback.swift
@@ -71,6 +71,8 @@ public protocol MediaPlayback: class {
     
     /// avplayer playerItem
     var playerItem: AVPlayerItem? { get }
+    
+    var isOfflinePlayable: Bool { get }
 }
 
 extension Player {
@@ -187,5 +189,11 @@ extension Player {
     /// Should returns the AVPlayerItem associated with the avplayer
     public var playerItem: AVPlayerItem?{
         return tech.playerItem
+    }
+    
+    public var isOfflinePlayable: Bool {
+        get {
+            return tech.isOfflinePlayable
+        }
     }
 }

--- a/Sources/iOSClientPlayer/Events/EventDispatcher.swift
+++ b/Sources/iOSClientPlayer/Events/EventDispatcher.swift
@@ -129,4 +129,11 @@ public class EventDispatcher<Context: MediaContext, Tech: PlaybackTech> {
     /// - parameter tech: `Tech` broadcasting the event
     /// - parameter source: `MediaSource` causing the event
     internal(set) public var onAppDidEnterBackground: (Tech, Context.Source?) -> Void = { _,_ in }
+    
+    
+    /// Should be triggered when the *AppDidEnterForeground*.
+    ///
+    /// - parameter tech: `Tech` broadcasting the event
+    /// - parameter source: `MediaSource` causing the event
+    internal(set) public var onAppDidEnterForeground: (Tech, Context.Source?) -> Void = { _,_ in }
 }

--- a/Sources/iOSClientPlayer/Events/EventDispatcher.swift
+++ b/Sources/iOSClientPlayer/Events/EventDispatcher.swift
@@ -110,4 +110,23 @@ public class EventDispatcher<Context: MediaContext, Tech: PlaybackTech> {
     
     /// Should be triggered when a *DateRangeMetadataChanged*.
     internal(set) public var onDateRangeMetadataChanged: (_ metaDataGroup: [AVDateRangeMetadataGroup], _ indexesOfNewGroups: IndexSet, _ indexesOfModifiedGroups: IndexSet ) -> Void = { _, _, _  in }
+    
+    /// Should be triggered when the *GracePeriodStarted*.
+    ///
+    /// - parameter tech: `Tech` broadcasting the event
+    /// - parameter source: `MediaSource` causing the event
+    internal(set) public var onGracePeriodStarted: (Tech, Context.Source?) -> Void = { _,_ in }
+
+    /// Should be triggered when the *GracePeriodEnded*.
+    ///
+    /// - parameter tech: `Tech` broadcasting the event
+    /// - parameter source: `MediaSource` causing the event
+    internal(set) public var onGracePeriodEnded: (Tech, Context.Source?) -> Void = { _,_ in }
+    
+    
+    /// Should be triggered when the *AppDidEnterBackground*.
+    ///
+    /// - parameter tech: `Tech` broadcasting the event
+    /// - parameter source: `MediaSource` causing the event
+    internal(set) public var onAppDidEnterBackground: (Tech, Context.Source?) -> Void = { _,_ in }
 }

--- a/Sources/iOSClientPlayer/Events/EventResponder.swift
+++ b/Sources/iOSClientPlayer/Events/EventResponder.swift
@@ -103,4 +103,28 @@ public protocol EventResponder {
     /// - parameter source: `MediaSource` causing the event
     /// - parameter warning: `Warning` encountered
     func onWarning<Tech, Source, Context>(tech: Tech, source: Source?, warning: PlayerWarning<Tech, Context>) where Tech: PlaybackTech, Source: MediaSource, Context: MediaContext
+    
+    
+    
+    /// Triggered when the app did enter background.
+    /// - Parameters:
+    ///   - tech: Tech` broadcasting the event
+    ///   - source: `MediaSource` causing the event
+    func onAppDidEnterBackground<Tech, Source>(tech: Tech, source: Source?) where Tech: PlaybackTech, Source: MediaSource
+    
+    //// Triggered when the grace period satrted
+    /// - Parameters:
+    ///   - tech: Tech` broadcasting the event
+    ///   - source: `MediaSource` causing the event
+    func onGracePeriodStarted<Tech, Source>(tech: Tech, source: Source?) where Tech: PlaybackTech, Source: MediaSource
+    
+    /// Triggered when the grace period ended
+    /// - Parameters:
+    ///   - tech: Tech` broadcasting the event
+    ///   - source: `MediaSource` causing the event
+    func onGracePeriodEnded<Tech, Source>(tech: Tech, source: Source?) where Tech: PlaybackTech, Source: MediaSource
+    
+    
+    
+
 }

--- a/Sources/iOSClientPlayer/Events/EventResponder.swift
+++ b/Sources/iOSClientPlayer/Events/EventResponder.swift
@@ -112,6 +112,13 @@ public protocol EventResponder {
     ///   - source: `MediaSource` causing the event
     func onAppDidEnterBackground<Tech, Source>(tech: Tech, source: Source?) where Tech: PlaybackTech, Source: MediaSource
     
+    
+    /// Triggered when the app did enter foreground.
+    /// - Parameters:
+    ///   - tech: Tech` broadcasting the event
+    ///   - source: `MediaSource` causing the event
+    func onAppDidEnterForeground<Tech, Source>(tech: Tech, source: Source?) where Tech: PlaybackTech, Source: MediaSource
+    
     //// Triggered when the grace period satrted
     /// - Parameters:
     ///   - tech: Tech` broadcasting the event

--- a/Sources/iOSClientPlayer/Tech/HLS/Components/HLSNative+MediaPlayback.swift
+++ b/Sources/iOSClientPlayer/Tech/HLS/Components/HLSNative+MediaPlayback.swift
@@ -12,7 +12,6 @@ import AVFoundation
 /// `HLSNative` adoption of `MediaPlayback`
 extension HLSNative: MediaPlayback {
     
-    
     /// Starts or resumes playback.
     public func play() {
         switch playbackState {
@@ -309,8 +308,8 @@ extension HLSNative: MediaPlayback {
             
             // Offline seek HACK :
             if #available(iOS 10.0, tvOS 10.0, *) {
-                if let urlAsset = currentAsset?.urlAsset, let accetCache = urlAsset.assetCache {
-                    if accetCache.isPlayableOffline {
+                if let urlAsset = currentAsset?.urlAsset, let assetCache = urlAsset.assetCache {
+                    if assetCache.isPlayableOffline {
                         offlineSeek(position)
                     } else {
                         seekToTimeWhenExternalPlayback(cmTime, timeInterval, callback: callback)
@@ -408,6 +407,16 @@ extension HLSNative: MediaPlayback {
     public var playerItem: AVPlayerItem? {
         get {
             return avPlayer.currentItem
+        }
+    }
+    
+    public var isOfflinePlayable: Bool {
+        get {
+            if let urlAsset = currentAsset?.urlAsset, let assetCache = urlAsset.assetCache {
+                return assetCache.isPlayableOffline
+            } else {
+                return false
+            }
         }
     }
 }

--- a/Sources/iOSClientPlayer/Tech/HLS/Components/HLSNative+MediaPlayback.swift
+++ b/Sources/iOSClientPlayer/Tech/HLS/Components/HLSNative+MediaPlayback.swift
@@ -127,7 +127,7 @@ extension HLSNative: MediaPlayback {
             chaseTime = cmTime;
             if !isSeekInProgress {
                 if let playerStatus = item?.status {
-                    trySeekToChaseTime(playerStatus)
+                    trySeekToChaseTime(playerStatus, seekTime: seekTime)
                 }
                 
             }
@@ -138,21 +138,21 @@ extension HLSNative: MediaPlayback {
 
     /// Try to do the seek
     /// - Parameter playerCurrentItemStatus: AVPlayerItem.Status
-    func trySeekToChaseTime( _ playerCurrentItemStatus: AVPlayerItem.Status) {
+    func trySeekToChaseTime( _ playerCurrentItemStatus: AVPlayerItem.Status, seekTime: Int64? = nil ) {
         if playerCurrentItemStatus == .unknown {
             // wait until item becomes ready (KVO player.currentItem.status)
             print("! wait until item becomes ready! ")
             print("\n")
         }
         else if playerCurrentItemStatus == .readyToPlay {
-            actuallySeekToTime() { _ in }
+            actuallySeekToTime(seekTime: seekTime) { _ in }
         }
     }
     
     
     /// Seek to Time in the player & assigned the text track back
     /// - Parameter callback: callback
-    private func actuallySeekToTime(callback: @escaping (Bool) -> Void = { _ in }) {
+    private func actuallySeekToTime(seekTime:Int64? = nil , callback: @escaping (Bool) -> Void = { _ in }) {
         
         self.isSeekInProgress = true
         let seekTimeInProgress = self.chaseTime
@@ -191,6 +191,11 @@ extension HLSNative: MediaPlayback {
                 }
             }
             
+            if success {
+                if let source = `self`.currentAsset?.source {
+                    `self`.eventDispatcher.onPlaybackScrubbed(`self`, source, seekTime ?? Int64(self.chaseTime.seconds))
+                    source.analyticsConnector.onScrubbedTo(tech: `self`, source: source, offset:seekTime ?? Int64(self.chaseTime.seconds)) }
+            }
             callback(success)
         }
         

--- a/Sources/iOSClientPlayer/Tech/HLS/HLSNative.swift
+++ b/Sources/iOSClientPlayer/Tech/HLS/HLSNative.swift
@@ -300,7 +300,10 @@ public final class HLSNative<Context: MediaContext>: PlaybackTech {
         }
         
         backgroundWatcher.handleWillEnterForeground { [weak self] in
-            self?.endGracePeriod()
+            guard let `self` = self else { return }
+            eventDispatcher.onAppDidEnterForeground(self, self.currentSource)
+            self.currentAsset?.source.analyticsConnector.onAppDidEnterForeground(tech: self, source: self.currentSource)
+            self.endGracePeriod()
         }
         backgroundWatcher.handleDidEnterBackground { [weak self] in
             /// `Dispatcher` (`Exposure` module) will force flush event queue on `.UIApplicationDidEnterBackground`

--- a/Sources/iOSClientPlayer/Tech/HLS/HLSNativeWarning.swift
+++ b/Sources/iOSClientPlayer/Tech/HLS/HLSNativeWarning.swift
@@ -27,6 +27,7 @@ public enum HLSNativeWarning: WarningMessage {
     
     /// Content Key Validation failed with the specified error, or `nil` if the underlyig error is expected.
     case coreMediaErrorDomain(error: Error?)
+ 
     
 }
 

--- a/Sources/iOSClientPlayer/Version.swift
+++ b/Sources/iOSClientPlayer/Version.swift
@@ -8,4 +8,4 @@
 import Foundation
 
 /// Global constant for framework version
-public let PlayerVersion = "3.1.600"
+public let PlayerVersion = "3.2.0"

--- a/Tests/iOSClientPlayerTests/PlayerTests.swift
+++ b/Tests/iOSClientPlayerTests/PlayerTests.swift
@@ -29,6 +29,9 @@ class TestAnalyticsProvider: AnalyticsProvider {
     var scrubbedTo: Int64? = nil
     var durationChanged = false
     var warningReceived = false
+    var appDidEnterBackground = false
+    var gracePeriodStarted = false
+    var gracePeriodEnded = false
     
     public init() { }
     
@@ -90,6 +93,18 @@ class TestAnalyticsProvider: AnalyticsProvider {
     
     func onWarning<Tech, Source, Context>(tech: Tech, source: Source?, warning: PlayerWarning<Tech, Context>) where Tech : PlaybackTech, Source : MediaSource, Context : MediaContext {
         warningReceived = true
+    }
+    
+    func onAppDidEnterBackground<Tech, Source>(tech: Tech, source: Source?) where Tech : iOSClientPlayer.PlaybackTech, Source : iOSClientPlayer.MediaSource {
+        appDidEnterBackground = true
+    }
+    
+    func onGracePeriodStarted<Tech, Source>(tech: Tech, source: Source?) where Tech : iOSClientPlayer.PlaybackTech, Source : iOSClientPlayer.MediaSource {
+        gracePeriodStarted = true
+    }
+    
+    func onGracePeriodEnded<Tech, Source>(tech: Tech, source: Source?) where Tech : iOSClientPlayer.PlaybackTech, Source : iOSClientPlayer.MediaSource {
+        gracePeriodEnded = true
     }
 }
 

--- a/Tests/iOSClientPlayerTests/PlayerTests.swift
+++ b/Tests/iOSClientPlayerTests/PlayerTests.swift
@@ -30,6 +30,7 @@ class TestAnalyticsProvider: AnalyticsProvider {
     var durationChanged = false
     var warningReceived = false
     var appDidEnterBackground = false
+    var appDidEnterForeground = false
     var gracePeriodStarted = false
     var gracePeriodEnded = false
     
@@ -97,6 +98,10 @@ class TestAnalyticsProvider: AnalyticsProvider {
     
     func onAppDidEnterBackground<Tech, Source>(tech: Tech, source: Source?) where Tech : iOSClientPlayer.PlaybackTech, Source : iOSClientPlayer.MediaSource {
         appDidEnterBackground = true
+    }
+    
+    func onAppDidEnterForeground<Tech, Source>(tech: Tech, source: Source?) where Tech : iOSClientPlayer.PlaybackTech, Source : iOSClientPlayer.MediaSource {
+        appDidEnterForeground = true
     }
     
     func onGracePeriodStarted<Tech, Source>(tech: Tech, source: Source?) where Tech : iOSClientPlayer.PlaybackTech, Source : iOSClientPlayer.MediaSource {

--- a/iOSClientPlayer.podspec
+++ b/iOSClientPlayer.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
 spec.name         = "iOSClientPlayer"
-spec.version      = "3.1.600"
+spec.version      = "3.2.0"
 spec.summary      = "RedBeeMedia iOS SDK Player Module"
 spec.homepage     = "https://github.com/EricssonBroadcastServices"
 spec.license      = { :type => "Apache", :file => "https://github.com/EricssonBroadcastServices/iOSClientPlayer/blob/master/LICENSE" }
 spec.author             = { "EMP" => "jenkinsredbee@gmail.com" }
 spec.documentation_url = "https://github.com/EricssonBroadcastServices/iOSClientPlayer/tree/master/Documentation"
-spec.platforms = { :ios => "10.0", :tvos => "10.0" }
+spec.platforms = { :ios => "12.0", :tvos => "12.0" }
 spec.source       = { :git => "https://github.com/EricssonBroadcastServices/iOSClientPlayer.git", :tag => "v#{spec.version}" }
 spec.source_files  = "Sources/iOSClientPlayer/**/*.swift"
 end

--- a/iOSClientPlayer.xcodeproj/project.pbxproj
+++ b/iOSClientPlayer.xcodeproj/project.pbxproj
@@ -755,7 +755,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.1.600;
+				MARKETING_VERSION = 3.2.0;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Player;
 				PRODUCT_NAME = iOSClientPlayer;
@@ -794,7 +794,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.1.600;
+				MARKETING_VERSION = 3.2.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Player;
@@ -945,7 +945,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/Frameworks @executable_path/Frameworks";
-				MARKETING_VERSION = 3.1.600;
+				MARKETING_VERSION = 3.2.0;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Player;
 				PRODUCT_NAME = iOSClientPlayer;
@@ -983,7 +983,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/Frameworks @executable_path/Frameworks";
-				MARKETING_VERSION = 3.1.600;
+				MARKETING_VERSION = 3.2.0;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Player;
 				PRODUCT_NAME = iOSClientPlayer;


### PR DESCRIPTION
- Add new analytics passthrough events : `onAppDidEnterBackground / onG…racePeriodEnded / onGracePeriodStarted`
- Pass if the media source is offline playable
- Start & End grace period when the app goes to the background